### PR TITLE
Adição da opção PKG_USE_MIPS16:=0

### DIFF
--- a/linux-eoip/Makefile
+++ b/linux-eoip/Makefile
@@ -36,10 +36,8 @@ define Package/linux-eoip
 endef
 
 define Package/linux-eoip/description
-	MakeFile para gerar o pacote Linux-EoIP para o firmware openwrt;
-	Fork Brasileiro;
-	Integração de túneis EoIP Mikrotik e linux.
-	
+  linux-eoip can create ethernet tunnels compatible with Mikrotik EoIP tunnel.
+  At current moment it is easiest way to create stateless tunnel with Mikrotik.
 endef
 
 TARGET_CFLAGS += -std=gnu99

--- a/linux-eoip/Makefile
+++ b/linux-eoip/Makefile
@@ -11,9 +11,12 @@ PKG_NAME:=linux-eoip
 PKG_VERSION:=0.5
 PKG_RELEASE:=1
 
+
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://linux-eoip.googlecode.com/files/
 PKG_MD5SUM:=b2a9746f9ae352f2c495422cb19900d8
+PKG_USE_MIPS16:=0
+
 
 PKG_INSTALL:=1
 
@@ -33,8 +36,9 @@ define Package/linux-eoip
 endef
 
 define Package/linux-eoip/description
-  linux-eoip can create ethernet tunnels compatible with Mikrotik EoIP tunnel.
-  At current moment it is easiest way to create stateless tunnel with Mikrotik.
+	MakeFile para gerar o pacote Linux-EoIP para o firmware openwrt;
+	Fork Brasileiro;
+	
 endef
 
 TARGET_CFLAGS += -std=gnu99

--- a/linux-eoip/Makefile
+++ b/linux-eoip/Makefile
@@ -38,6 +38,7 @@ endef
 define Package/linux-eoip/description
 	MakeFile para gerar o pacote Linux-EoIP para o firmware openwrt;
 	Fork Brasileiro;
+	Integração de túneis EoIP Mikrotik e linux.
 	
 endef
 


### PR DESCRIPTION
Esta opção se fez necessária para realizar a compilação com sucesso. 
